### PR TITLE
adding attribute number range verification

### DIFF
--- a/stackzilla/attribute/attribute.py
+++ b/stackzilla/attribute/attribute.py
@@ -3,13 +3,16 @@
 
 from typing import Any, List
 
+from stackzilla.utils.numbers import StackzillaRange
 
+
+# pylint: disable=too-many-instance-attributes
 class StackzillaAttribute:
     """Descriptor class for all blueprint attributes."""
 
     # pylint: disable=too-many-arguments
     def __init__(self, required: bool = False, default: Any = None, choices: List[Any] = None,
-                 modify_rebuild: bool = False, dynamic: bool = False, secret: bool = False):
+                 modify_rebuild: bool = False, dynamic: bool = False, secret: bool = False, number_range: StackzillaRange = None):
         """Constructor for the attribute.
 
         Args:
@@ -17,6 +20,7 @@ class StackzillaAttribute:
             default (Any, optional): The value for the parameter if none is specified. Defaults to None.
             choices (List[Any], optional): List of valid values for the parameter. Defaults to None.
             modify_rebuild (bool, optional): Rebuild the resource if true and parameter is modified. Defaults to False.
+            number_range (StackzillaRange, optional): Minimum and maximum allowable int or float values. Defaults to None.
             dynamic (bool, optional): The parameter is set programatically and not by the user. Defaults to False.
             secret (bool, optional): Parameter holds sensitive information. Defaults to False.
         """
@@ -24,6 +28,7 @@ class StackzillaAttribute:
         self.default = default
         self.dynamic = dynamic
         self.modify_rebuild = modify_rebuild
+        self.number_range = number_range
         self.required = required
         self.secret = secret
 

--- a/stackzilla/attribute/tests/test_attribute.py
+++ b/stackzilla/attribute/tests/test_attribute.py
@@ -1,6 +1,7 @@
 import inspect
 
 from stackzilla.attribute import StackzillaAttribute
+from stackzilla.utils.numbers import StackzillaRange
 
 
 class Class:
@@ -11,7 +12,7 @@ class Class:
     default_int = StackzillaAttribute(default=42)
     default_float = StackzillaAttribute(default=88.0)
     default_string = StackzillaAttribute(default='GREAT SCOTT!')
-
+    range_arg = StackzillaAttribute(number_range=StackzillaRange(min=42, max=88), default=50)
 
 class Instance:
     """ The parameters in this class are defined in the constructor as instance variables. """
@@ -31,7 +32,6 @@ class MyClass(Class):
         super().__init__()
         self.default_float = 69.0
         self.required_arg = "Stackzilla"
-
 
 
 class ChildObject(Class):
@@ -113,7 +113,8 @@ def test_programatic_access():
             attribute_count += 1
             print(f'{name} : {my_class.__dict__.get(name, value.default)}')
 
-    assert attribute_count == 6
+    assert attribute_count == 7
     assert my_class.required_arg == "Stackzilla"
     assert my_class.default_string == "GREAT SCOTT!"
     assert my_class.default_int == 42
+    assert my_class.range_arg == 50

--- a/stackzilla/resource/base.py
+++ b/stackzilla/resource/base.py
@@ -99,6 +99,13 @@ class StackzillaResource:
             if attribute.dynamic and attr_value is not None:
                 verify_error_info.add_attribute_error(name=attr_name, error='Attribute is dynamic value can not be specified.')
 
+            if attribute.number_range and attribute.number_range.in_range(attr_value) is False:
+                attr_min = attribute.number_range.min
+                attr_max = attribute.number_range.max
+
+                verify_error_info.add_attribute_error(
+                    name=attr_name, error=f'Attribute value ({attr_value}) not in range [{attr_min} - {attr_max}].')
+
         if verify_error_info.attribute_errors:
             raise verify_error_info
 

--- a/stackzilla/utils/numbers.py
+++ b/stackzilla/utils/numbers.py
@@ -1,0 +1,22 @@
+"""Module for numerical utilities in Stackzilla."""
+from dataclasses import dataclass
+from typing import Union
+
+
+@dataclass
+class StackzillaRange:
+    """Defines the minimum and maximum values for an attribute range check."""
+
+    min: Union[int, float]
+    max: Union[int, float]
+
+    def in_range(self, value: Union[int, float]) -> bool:
+        """Test if the specified value is within the range.
+
+        Args:
+            value (Union[int, float]): The value to test
+
+        Returns:
+            bool: True if the value is within the range, False otherwise.
+        """
+        return self.min <= value <= self.max


### PR DESCRIPTION
Attributes can now have a number range associated with them to allow for automatic range checking during blueprint verification. 