### PR TITLE
attribute modification failure

### DIFF
--- a/stackzilla/cli/blueprint.py
+++ b/stackzilla/cli/blueprint.py
@@ -8,7 +8,8 @@ from stackzilla.blueprint import StackzillaBlueprint
 from stackzilla.blueprint.exceptions import BlueprintVerifyFailure
 from stackzilla.database.base import StackzillaDB
 from stackzilla.diff import StackzillaDiff, StackzillaDiffResult
-from stackzilla.diff.exceptions import ApplyErrors
+from stackzilla.diff.exceptions import (ApplyErrors,
+                                        UnhandledAttributeModifications)
 from stackzilla.graph import Graph
 from stackzilla.utils.constants import DISK_BP_PREFIX
 
@@ -69,6 +70,12 @@ def apply(path):
                 for error in exc.errors:
                     click.echo(error)
                 raise click.ClickException('Apply failed - see errors above.')
+            except UnhandledAttributeModifications as exc:
+                for attr in exc.unhandled_attributes:
+                    click.echo(f'ERROR: Unhandled attribute modification - {attr.name}')
+                    raise click.ClickException(
+                        'Unhanlded attribute modifications. Please contact the provider author and report this bug.')
+
     else:
         click.echo('No differences')
 

--- a/stackzilla/cli/database.py
+++ b/stackzilla/cli/database.py
@@ -1,10 +1,37 @@
 """Module for database debugging CLI."""
+import pprint
+
 import click
 
-#from stackzilla.database.base import StackzillaDB
-#from stackzilla.blueprint import StackzillaBlueprint
-#from stackzilla.database.exceptions import ResourceNotFound
+from stackzilla.blueprint import StackzillaBlueprint
+from stackzilla.database.base import StackzillaDB
+from stackzilla.database.exceptions import ResourceNotFound
+from stackzilla.resource.base import StackzillaResource
+from stackzilla.utils.constants import DISK_BP_PREFIX
+
+from .options import path_option
+
 
 @click.group(name='database')
 def database():
     """Command group for all database CLI commands."""
+
+@database.command('show-resource')
+@path_option
+def show_resource(path):
+    """Show a resource, and its attributes, as it is in the database."""
+    StackzillaDB.db.open()
+
+    # Import the blueprint from disk
+    db_blueprint = StackzillaBlueprint(python_root=DISK_BP_PREFIX)
+    db_blueprint.load()
+
+    # Load the resource specified by path
+    try:
+        resource: StackzillaResource = db_blueprint.get_resource(path=path)
+        resource = resource()
+        resource.load_from_db()
+    except ResourceNotFound as exc:
+        raise click.ClickException('Resource specified by path not found') from exc
+
+    pprint.pprint(resource.__dict__)

--- a/stackzilla/database/sqlite.py
+++ b/stackzilla/database/sqlite.py
@@ -405,6 +405,7 @@ class StackzillaSQLiteDB(StackzillaDBBase):
         }
 
         self.connection.execute(update_sql, update_data)
+        self.connection.commit()
 
     def get_attribute(self, resource: StackzillaResource, name: str) -> Any:
         """Fetch a single attribute from the dataase.
@@ -516,7 +517,7 @@ class StackzillaSQLiteDB(StackzillaDBBase):
         }
 
         self.connection.execute(update_sql, update_data)
-
+        self.connection.commit()
 
     def delete_blueprint_module(self, path: str) -> None:
         """Delete an existing module.
@@ -571,11 +572,13 @@ class StackzillaSQLiteDB(StackzillaDBBase):
         blueprint_package_id = self._get_blueprint_package_id(path=path)
         delete_sql = 'DELETE FROM StackzillaBlueprintPackage WHERE id=:id'
         self.connection.execute(delete_sql, {'id': blueprint_package_id})
+        self.connection.commit()
 
     def delete_all_blueprint_packages(self) -> None:
         """Delete all of the blueprint packages from the database."""
         delete_sql = 'DELETE FROM StackzillaBlueprintPackage'
         self.connection.execute(delete_sql)
+        self.connection.commit()
 
     def get_blueprint_package(self, path: str) -> bool:
         """Queries if a blueprint package exists in the database.

--- a/stackzilla/provider/null/base.py
+++ b/stackzilla/provider/null/base.py
@@ -1,15 +1,20 @@
 """Base boilerplate for NULL resources."""
-from typing import List
+from typing import Any, List
 
+from stackzilla.attribute.attribute import StackzillaAttribute
 from stackzilla.logger.provider import ProviderLogger
 from stackzilla.resource.base import ResourceVersion, StackzillaResource
-from stackzilla.resource.exceptions import ResourceCreateFailure
+from stackzilla.resource.exceptions import (AttributeModifyFailure,
+                                            ResourceCreateFailure)
 
 
 class BaseNullResource(StackzillaResource):
     """Base boilerplate for NULL resources."""
 
     create_failure = False
+
+    # When this attribute is modified, an exception will be raised in its on_modified() handler!
+    mod_fail = StackzillaAttribute(default='modify at y0ur own perilz!')
 
     def __init__(self, provider_name: str) -> None:
         """Create the logger."""
@@ -33,6 +38,10 @@ class BaseNullResource(StackzillaResource):
     def depends_on(self) -> List['StackzillaResource']:
         """Required to be overridden."""
         return []
+
+    def mod_fail_modified(self, previous_value: Any, new_value: Any) -> None:
+        """Modificaiton handler which will always raise an exception."""
+        raise AttributeModifyFailure(attribute_name='mod_fail', reason='Built-in test failure')
 
     @classmethod
     def version(cls) -> ResourceVersion:

--- a/stackzilla/provider/null/instance.py
+++ b/stackzilla/provider/null/instance.py
@@ -1,4 +1,6 @@
 """Test resource provider that mimics a storage volume."""
+from typing import Any
+
 from stackzilla.attribute.attribute import StackzillaAttribute
 from stackzilla.provider.null.base import BaseNullResource
 
@@ -11,3 +13,7 @@ class Instance(BaseNullResource):
     def __init__(self) -> None:
         """Default constructor that sets up logging."""
         super().__init__(provider_name='stackzilla.provider.null.instance')
+
+    def type_modified(self, previous_value: Any, new_value: Any) -> None:
+        """Handle when the type is modified (does nothing but log a message)."""
+        self._logger.debug(f'Modifying type from {previous_value} to {new_value}')

--- a/stackzilla/resource/base.py
+++ b/stackzilla/resource/base.py
@@ -2,13 +2,14 @@
 import inspect
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from stackzilla.attribute import StackzillaAttribute
 from stackzilla.database.base import StackzillaDB
 from stackzilla.database.exceptions import AttributeNotFound, ResourceNotFound
 from stackzilla.logger.core import CoreLogger
-from stackzilla.resource.exceptions import ResourceVerifyError
+from stackzilla.resource.exceptions import (AttributeModifyFailure,
+                                            ResourceVerifyError)
 from stackzilla.utils.constants import DB_BP_PREFIX, DISK_BP_PREFIX
 from stackzilla.utils.string import removeprefix
 
@@ -21,6 +22,7 @@ class AttributeModified:
     previous_value: Any
     new_value: Any
     handled: bool = False
+    error: Optional[AttributeModifyFailure] = None
 
 
 @dataclass

--- a/stackzilla/resource/exceptions.py
+++ b/stackzilla/resource/exceptions.py
@@ -4,6 +4,16 @@ from typing import Dict, List
 from colorama import Fore, Style
 
 
+class AttributeModifyFailure(Exception):
+    """Raised when an attribute modification fails in an on_*_modified() handler."""
+
+    def __init__(self, attribute_name: str, reason: str, *args: object) -> None:
+        """Default constructor."""
+        super().__init__(*args)
+
+        self.attribute_name: str = attribute_name
+        self.reason: str = reason
+
 class ResourceCreateFailure(Exception):
     """Raised when a resource creation fails."""
 


### PR DESCRIPTION
- Handle when a `*_modified()` raises an exception
- Fixed a bug with the DB not committing a transaction during attribute persistence
- Added DB debug command
- Added new `mod_fail` attribute to base NULL provider (will fail if it's modified)

Fixes issue #30 