### PR TITLE
binary only for crypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click==8.1.3
 colorama==0.4.5
-cryptography==38.0.1 --only-binary=cryptography
+cryptography==38.0.1
 parallel-ssh==2.12.0
+--only-binary=cryptography


### PR DESCRIPTION
Only install the binary wheel for the cryptography library.