### PR TITLE
multithreaded apply

### DIFF
--- a/stackzilla/database/base.py
+++ b/stackzilla/database/base.py
@@ -112,16 +112,6 @@ class StackzillaDBBase(ABC):
     # Methods for interacting with StackzillaAttribute objects
     ###############################################################################
     @abstractmethod
-    def create_attribute(self, resource: 'StackzillaResource', name: str, value: Any):
-        """Adds a new attribute to the database.
-
-        Args:
-            resource (StackzillaResource): The parent resource for the attribute being created
-            name (str): The name of the attribute to create
-            value (Any): The value to assign to the newly created attribute
-        """
-
-    @abstractmethod
     def get_attribute(self, resource: 'StackzillaResource', name: str) -> Any:
         """Fetch the value for an attribute.
 

--- a/stackzilla/database/exceptions.py
+++ b/stackzilla/database/exceptions.py
@@ -1,5 +1,8 @@
 """Exceptions for the database module."""
 
+class DatabaseCommitError(Exception):
+    """Raised when a database commit operation fails."""
+
 class DatabaseExists(Exception):
     """Raised if the database already exists during a create operation."""
 

--- a/stackzilla/database/tests/test_concurrency.py
+++ b/stackzilla/database/tests/test_concurrency.py
@@ -1,6 +1,7 @@
 """Verify that multi-threaded database access works."""
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from time import sleep
+from typing import List
 from uuid import UUID, uuid4
 
 from stackzilla.attribute import StackzillaAttribute
@@ -20,7 +21,7 @@ class Resource(StackzillaResource):
     def version(cls) -> ResourceVersion:
         return ResourceVersion(major=1, minor=0, build=0, name='FCS')
 
-def db_write_worker(database: StackzillaSQLiteDB, range: list[int]):
+def db_write_worker(database: StackzillaSQLiteDB, range: List[int]):
     """Dynamically create resource classes and add them to the database."""
     for index in range:
         new_class = type(f'MyResource{index}', (Resource,), {})

--- a/stackzilla/database/tests/test_concurrency.py
+++ b/stackzilla/database/tests/test_concurrency.py
@@ -1,0 +1,77 @@
+"""Verify that multi-threaded database access works."""
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from time import sleep
+from uuid import UUID, uuid4
+
+from stackzilla.attribute import StackzillaAttribute
+from stackzilla.database.sqlite import StackzillaSQLiteDB
+from stackzilla.resource import ResourceVersion, StackzillaResource
+
+resources = []
+class Resource(StackzillaResource):
+    """Demo resource."""
+    uuid: UUID = StackzillaAttribute(required=True)
+    required = StackzillaAttribute(required=True)
+    default_int = StackzillaAttribute(required=False, default=42)
+    list_attr = StackzillaAttribute(required=False)
+    dict_attr = StackzillaAttribute(required=False)
+
+    @classmethod
+    def version(cls) -> ResourceVersion:
+        return ResourceVersion(major=1, minor=0, build=0, name='FCS')
+
+def db_write_worker(database: StackzillaSQLiteDB, range: list[int]):
+    """Dynamically create resource classes and add them to the database."""
+    for index in range:
+        new_class = type(f'MyResource{index}', (Resource,), {})
+        globals()[f'MyResource{index}'] = new_class
+        my_resource = new_class()
+        my_resource.uuid = uuid4()
+        resources.append(my_resource)
+        database.create_resource(resource=my_resource)
+
+        # Give the other threads a chance to play
+        sleep(0.01)
+
+
+def db_read_worker(database: StackzillaSQLiteDB, cycles: int):
+    """Helper function which read all resources from the database."""
+    for _ in range(cycles):
+        # Give the other threads a chance to play
+        sleep(0.01)
+        database.get_all_resources()
+
+def test_multiple_writes(database: StackzillaSQLiteDB):
+    """Write multiple objects to the database at the same time."""
+    futures = []
+    with ThreadPoolExecutor() as executor:
+        futures.append(executor.submit(db_write_worker, database=database, range=range(0, 10, 1)))
+        futures.append(executor.submit(db_write_worker, database=database, range=range(10, 20, 1)))
+        futures.append(executor.submit(db_write_worker, database=database, range=range(20, 30, 1)))
+
+    for result in as_completed(futures):
+        assert result.exception() is None
+        assert result.result() is None
+
+    # Make sure all of the resources made it into the database
+    assert len(database.get_all_resources()) == 30
+
+    # Iterate over each resource and ensure they can be queried by path
+    for index in range(0, 30, 1):
+        resource_name = f'database.tests.test_concurrency.MyResource{index}'
+        database.get_resource(path=resource_name)
+
+def test_multi_read_write(database: StackzillaSQLiteDB):
+    """Verify that reading and writing to the database at the same time works."""
+    futures = []
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        # Create a bunch of resources
+        futures.append(executor.submit(db_write_worker, database=database, range=range(0, 50, 1)))
+
+        # While simultaneously reading everything from the database over and over
+        print('starting read')
+        futures.append(executor.submit(db_read_worker, database=database, cycles=50))
+
+    for result in as_completed(futures):
+        assert result.exception() is None
+        assert result.result() is None

--- a/stackzilla/database/tests/test_resource.py
+++ b/stackzilla/database/tests/test_resource.py
@@ -51,9 +51,7 @@ def test_create_resource(database: StackzillaSQLiteDB):
     my_other_resource = MyOtherResource()
 
     database.create_resource(resource=my_resource)
-    for name in my_resource.attributes:
-        database.create_attribute(resource=my_resource, name=name, value=getattr(my_resource, name))
-
+ 
     db_resource = database.get_resource(path='database.tests.test_resource.MyResource')
     assert db_resource.__class__ == MyResource
     assert db_resource.version() == MyResource.version()
@@ -107,10 +105,6 @@ def test_duplicate_attributes(database: StackzillaSQLiteDB):
     my_resource = MyResource()
     my_resource.create_in_db()
 
-    # Snag a random attribute to persist to the database
-    with pytest.raises(DuplicateAttribute):
-        database.create_attribute(resource=my_resource, name='default_int', value=getattr(my_resource, 'default_int'))
-
 def test_invalid_delete_attribute(database: StackzillaSQLiteDB):
     """When deleting, make sure the correct exception is raised for attributes not in the database."""
     my_resource = MyResource()
@@ -134,9 +128,6 @@ def test_update_attribute(database: StackzillaSQLiteDB):
     """Ensure that updating attibutes in the database. works"""
     my_resource = MyResource()
     database.create_resource(resource=my_resource)
-
-    # Create the resource in the database with its default value
-    database.create_attribute(resource=my_resource, name='default_int', value=getattr(my_resource, 'default_int'))
 
     value = database.get_attribute(resource=my_resource, name='default_int')
     assert value == my_resource.default_int

--- a/stackzilla/diff/diff.py
+++ b/stackzilla/diff/diff.py
@@ -1,4 +1,5 @@
 """Module that has all of the logic for diffing imported blueprints."""
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from enum import Enum, auto
 from io import StringIO
@@ -218,104 +219,124 @@ class StackzillaDiff:
             StackzillaDB.db.create_blueprint_module(path=module.path, data=module.data)
 
         errors: List[str] = []
-        # pylint: disable=too-many-nested-blocks
         for phase in phases:
 
-            # Get the diffs for each resource in the phase
-            for resource in phase:
-                obj = resource()
+            with ThreadPoolExecutor() as executor:
 
-                # Need to load the resource from the database so that any dynamic attributes are present
-                # NOTE: If the resource is not in the database, no big deal, we'll just silently fail
-                obj.load_from_db(silent_fail=True)
+                # Apply the diff for all of the resources in this phase
+                futures = []
+                for resource in phase:
 
-                diff: StackzillaResourceDiff = self._result.resource_diffs[obj.path()]
+                    obj = resource()
+                    futures.append(executor.submit(self._apply_resource, obj=obj))
 
-                if diff.result == StackzillaDiffResult.CONFLICT:
+                # Process the results
+                for result in as_completed(futures):
+                    exception = result.exception()
+                    if exception:
 
-                    # Build a dictionary of AttributeModified objects to track what has and hasn't been handled.
-                    modified_attrs = {}
-                    for attr_name, attr_diff in diff.attribute_diffs.items():
-                        modified_attrs[attr_name] = AttributeModified(name=attr_name,
-                                                                      previous_value=attr_diff.dest_value,
-                                                                      new_value=attr_diff.src_value,
-                                                                      handled=False)
+                        # If this is a provider error, raise it immediately.
+                        if isinstance(exception, UnhandledAttributeModifications):
+                            raise exception
 
-                    # Invoke any StackzillaResource::*_modified() handlers
-                    for attr_name, attr_diff in diff.attribute_diffs.items():
-                        # _on_attribute_modified() should only be accessed from here.
-                        # pylint: disable=protected-access
-                        try:
-                            if obj._on_attribute_modified(attribute_name=attr_name,
-                                                          previous_value=attr_diff.dest_value,
-                                                          new_value=attr_diff.src_value):
-
-                                # Note that the attribute modification has been handled
-                                modified_attrs[attr_name].handled = True
-                        except AttributeModifyFailure as exc:
-                            modified_attrs[attr_name].error = exc
-
-                    # Invoke the "all-in-one" handler
-                    obj.on_attributes_modified(attributes=modified_attrs)
-
-                    # Check for any unhandled attributes
-                    unhandled_attributes = []
-                    for attribute in modified_attrs.values():
-                        # Just log an error and continue onward. Do NOT persist the value to the database.
-                        if attribute.error:
-                            errors.append(f'{obj.path(remove_prefix=True)}: {attribute.name} - {attribute.error.reason} ')
-                        elif attribute.handled is False:
-                            # The attribute wasn't handled - get ready to log a failure!
-                            unhandled_attributes.append(attribute)
+                        if isinstance(exception, ApplyErrors):
+                            errors.extend(exception.errors)
                         else:
-                            # Persist the attribute to the database
-                            StackzillaDB.db.update_attribute(resource=obj, name=attribute.name, value=attribute.new_value)
-
-                    if unhandled_attributes:
-
-                        if errors:
-                            self._logger.critical('Attribute modify encountered during unhandled attribute exception')
-                            self._logger.critical(errors)
-
-                        # Since this is actually a provider failure (usually hit during creation of the provider) it will
-                        # raise its own excption and "mask" the modify attribute failures. The developer should fix this
-                        # issue first!
-                        raise UnhandledAttributeModifications(unhandled_attributes)
-                elif diff.result == StackzillaDiffResult.REBUILD_REQUIRED:
-                    diff.dest_resource.delete()
-                    try:
-                        diff.src_resource.create()
-                        diff.src_resource.on_create_done.invoke(sender=diff.src_resource)
-                    except ResourceCreateFailure as exc:
-                        errors.append(f'{exc.resource_name}: {exc.reason}')
-                    except HandlerException as exc:
-                        errors.append(f'on_create_done handler failed with: {str(exc)}')
-
-                elif diff.result == StackzillaDiffResult.DELETED:
-                    try:
-                        diff.dest_resource.delete()
-                    except ResourceDeleteFailure as exc:
-                        errors.append(f'{exc.resource_name}: {exc.reason}')
-                elif diff.result == StackzillaDiffResult.NEW:
-                    try:
-                        diff.src_resource.create()
-                        diff.src_resource.on_create_done.invoke(sender=diff.src_resource)
-                    except ResourceCreateFailure as exc:
-                        errors.append(f'{exc.resource_name}: {exc.reason}')
-                    except HandlerException as exc:
-                        errors.append(str(exc))
-
-                elif diff.result == StackzillaDiffResult.SAME:
-                    continue
-                else:
-                    raise RuntimeError('Unhandled state')
-
-            # If there were errors in this phase, do not continue
+                            errors.append(str(exception))
             if errors:
                 raise ApplyErrors(errors=errors)
 
+    def _apply_resource(self, obj: StackzillaResource):
 
+        errors = []
 
+        # Need to load the resource from the database so that any dynamic attributes are present
+        # NOTE: If the resource is not in the database, no big deal, we'll just silently fail
+        obj.load_from_db(silent_fail=True)
+
+        diff: StackzillaResourceDiff = self._result.resource_diffs[obj.path()]
+
+        if diff.result == StackzillaDiffResult.CONFLICT:
+
+            # Build a dictionary of AttributeModified objects to track what has and hasn't been handled.
+            modified_attrs = {}
+            for attr_name, attr_diff in diff.attribute_diffs.items():
+                modified_attrs[attr_name] = AttributeModified(name=attr_name,
+                                                                previous_value=attr_diff.dest_value,
+                                                                new_value=attr_diff.src_value,
+                                                                handled=False)
+
+            # Invoke any StackzillaResource::*_modified() handlers
+            for attr_name, attr_diff in diff.attribute_diffs.items():
+                # _on_attribute_modified() should only be accessed from here.
+                # pylint: disable=protected-access
+                try:
+                    if obj._on_attribute_modified(attribute_name=attr_name,
+                                                    previous_value=attr_diff.dest_value,
+                                                    new_value=attr_diff.src_value):
+
+                        # Note that the attribute modification has been handled
+                        modified_attrs[attr_name].handled = True
+                except AttributeModifyFailure as exc:
+                    modified_attrs[attr_name].error = exc
+
+            # Invoke the "all-in-one" handler
+            obj.on_attributes_modified(attributes=modified_attrs)
+
+            # Check for any unhandled attributes
+            unhandled_attributes = []
+            for attribute in modified_attrs.values():
+                # Just log an error and continue onward. Do NOT persist the value to the database.
+                if attribute.error:
+                    errors.append(f'{obj.path(remove_prefix=True)}: {attribute.name} - {attribute.error.reason} ')
+                elif attribute.handled is False:
+                    # The attribute wasn't handled - get ready to log a failure!
+                    unhandled_attributes.append(attribute)
+                else:
+                    # Persist the attribute to the database
+                    StackzillaDB.db.update_attribute(resource=obj, name=attribute.name, value=attribute.new_value)
+
+            if unhandled_attributes:
+
+                if errors:
+                    self._logger.critical('Attribute modify encountered during unhandled attribute exception')
+                    self._logger.critical(errors)
+
+                # Since this is actually a provider failure (usually hit during creation of the provider) it will
+                # raise its own excption and "mask" the modify attribute failures. The developer should fix this
+                # issue first!
+                raise UnhandledAttributeModifications(unhandled_attributes)
+        elif diff.result == StackzillaDiffResult.REBUILD_REQUIRED:
+            diff.dest_resource.delete()
+            try:
+                diff.src_resource.create()
+                diff.src_resource.on_create_done.invoke(sender=diff.src_resource)
+            except ResourceCreateFailure as exc:
+                errors.append(f'{exc.resource_name}: {exc.reason}')
+            except HandlerException as exc:
+                errors.append(f'on_create_done handler failed with: {str(exc)}')
+
+        elif diff.result == StackzillaDiffResult.DELETED:
+            try:
+                diff.dest_resource.delete()
+            except ResourceDeleteFailure as exc:
+                errors.append(f'{exc.resource_name}: {exc.reason}')
+        elif diff.result == StackzillaDiffResult.NEW:
+            try:
+                diff.src_resource.create()
+                diff.src_resource.on_create_done.invoke(sender=diff.src_resource)
+            except ResourceCreateFailure as exc:
+                errors.append(f'{exc.resource_name}: {exc.reason}')
+            except HandlerException as exc:
+                errors.append(str(exc))
+
+        elif diff.result == StackzillaDiffResult.SAME:
+            return
+        else:
+            raise RuntimeError('Unhandled state')
+
+        if errors:
+            raise ApplyErrors(errors=errors)
 
     # pylint: disable=too-many-branches,too-many-locals
     def diff(self, source: Optional[StackzillaBlueprint], destination: Optional[StackzillaBlueprint]):

--- a/stackzilla/diff/diff.py
+++ b/stackzilla/diff/diff.py
@@ -184,7 +184,7 @@ class StackzillaDiff:
 
         return self._result
 
-    # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    # pylint: disable=too-many-locals,too-many-branches
     def apply(self):
         """Resolve the blueprint graph and apply differences."""
         # Create a graph from the source blueprint
@@ -223,6 +223,8 @@ class StackzillaDiff:
 
             with ThreadPoolExecutor() as executor:
 
+                self._logger.debug(f'Resources being applied in this phase: {phase}')
+
                 # Apply the diff for all of the resources in this phase
                 futures = []
                 for resource in phase:
@@ -246,9 +248,14 @@ class StackzillaDiff:
             if errors:
                 raise ApplyErrors(errors=errors)
 
+    # pylint: disable=too-many-branches,too-many-locals,too-many-statements,line-too-long
     def _apply_resource(self, obj: StackzillaResource):
-
+        """Apply the diff for a spacified resource."""
         errors = []
+
+        # Ugly as sin, but has to be done per this: https://parallel-ssh.readthedocs.io/en/latest/scaling.html?highlight=thread#scaling
+        # pylint: disable=unused-import,import-outside-toplevel
+        import pssh.clients.ssh
 
         # Need to load the resource from the database so that any dynamic attributes are present
         # NOTE: If the resource is not in the database, no big deal, we'll just silently fail

--- a/stackzilla/resource/base.py
+++ b/stackzilla/resource/base.py
@@ -291,9 +291,6 @@ class StackzillaResource(metaclass=SZMeta):
         """Persist the resource, and its attributes, in the database."""
         StackzillaDB.db.create_resource(resource=self)
 
-        for name in self.attributes:
-            StackzillaDB.db.create_attribute(resource=self, name=name, value=getattr(self, name))
-
     def delete_from_db(self):
         """Delete the resource, and all its attributes, from the database."""
         for name in self.attributes:


### PR DESCRIPTION
Adding support for executing applies within a phase via multiple threads.
- Add locking around database operations so that only one operation can be performed at a time
- Shifted around diff.apply() logic to support thread executor
- Updated the database layer to require resources creation to also create its attributes (for easier multithreading)

For issue #7 