### PR TITLE
DB caching and load helper

### DIFF
--- a/stackzilla/cli/blueprint.py
+++ b/stackzilla/cli/blueprint.py
@@ -187,13 +187,12 @@ def delete(dry_run):
         click.echo(f'Resources in this deletion phase {resources_in_phase}')
 
         for resource in phase:
-            obj = resource()
 
             try:
-                obj.load_from_db()
+                obj = resource.from_db()
             except ResourceNotFound:
                 # The resource was not found likely due to it not being correctly applied previously.
-                click.echo(f'{obj.path(remove_prefix=True)} was not in the database. Skipping.')
+                click.echo(f'{resource().path(remove_prefix=True)} was not in the database. Skipping.')
                 continue
 
             if dry_run is False:

--- a/stackzilla/cli/resource.py
+++ b/stackzilla/cli/resource.py
@@ -26,9 +26,8 @@ def show(path):
 
     # Load the resource specified by path
     try:
-        resource_obj: StackzillaResource = db_blueprint.get_resource(path=path)
-        resource_obj = resource_obj()
-        resource_obj.load_from_db()
+        resource_class: StackzillaResource = db_blueprint.get_resource(path=path)
+        resource_obj = resource_class.from_db()
     except ResourceNotFound as exc:
         raise click.ClickException('Resource specified by path not found') from exc
 

--- a/stackzilla/cli/utils.py
+++ b/stackzilla/cli/utils.py
@@ -21,13 +21,12 @@ def get_resource_from_path(path: str, resource_type: Optional[Type]=StackzillaRe
     # Load the resource specified by path
     try:
         resource: StackzillaResource = db_blueprint.get_resource(path=path)
-        resource = resource()
-        resource.load_from_db()
+        obj = resource.from_db()
 
         # Perform a type check
-        if issubclass(resource.__class__, resource_type) is False:
-            raise click.ClickException(f'{resource.path()} is not a {resource_type} resource.')
+        if issubclass(obj.__class__, resource_type) is False:
+            raise click.ClickException(f'{obj.path()} is not a {resource_type} resource.')
 
-        return resource
+        return obj
     except ResourceNotFound as exc:
         raise click.ClickException('Resource specified by path not found') from exc

--- a/stackzilla/database/sqlite.py
+++ b/stackzilla/database/sqlite.py
@@ -517,7 +517,7 @@ class StackzillaSQLiteDB(StackzillaDBBase):
             resource (StackzillaResource): The StackzillaResource that the attribute belongs to
             name (str): Name of the attribute as it's definined in the StackzillaResource class
             update_cache(bool): If True, skip reading from the attribute cache and pull from the DB.
-            
+
         Raises:
             AttributeNotFound: Raised if the attribute is not found in the database
 

--- a/stackzilla/resource/base.py
+++ b/stackzilla/resource/base.py
@@ -272,20 +272,37 @@ class StackzillaResource(metaclass=SZMeta):
         # There was no *_modified() method
         return False
 
-    def load_from_db(self, silent_fail: bool=False):
-        """Import all of the attribute values from the database."""
+    @classmethod
+    def from_db(cls, silent_fail: bool=False) -> 'StackzillaResource':
+        """Instantiate a copy of this object and load its attributes from the database.
+
+        Args:
+            silent_fail (bool, optional): If a failure occurs, skip raising an exception. Defaults to False.
+
+        Raises:
+            ResourceNotFound: Raised if the resource is not found in the database
+
+        Returns:
+            StackzillaResource: An instance of the class. None is returned if an error occurs and silent_fail is True.
+        """
+        # Instantiate a new object
+        obj = cls()
+
+        # Load all of the attributes from the database
         try:
-            for attribute_name in self.attributes:
-                value = StackzillaDB.db.get_attribute(resource=self, name=attribute_name)
-                setattr(self, attribute_name, value)
+            for attribute_name in obj.attributes:
+                value = StackzillaDB.db.get_attribute(resource=obj, name=attribute_name)
+                setattr(obj, attribute_name, value)
         except ResourceNotFound as err:
             if silent_fail is True:
-                return
+                return None
 
             raise err
 
         # Load the version number from the database
-        self._saved_version = StackzillaDB.db.get_resource_version(resource=self)
+        obj._saved_version = StackzillaDB.db.get_resource_version(resource=obj)
+
+        return obj
 
     def create_in_db(self):
         """Persist the resource, and its attributes, in the database."""


### PR DESCRIPTION
Adding a caching layer for the resource attributes. The cache is threadsafe and will prevent multiple hits to the database for lookups. In addition, added a helper method for quickly loading resources in a single call: `from_db()`

Closes out issue #55 